### PR TITLE
Update build.gradle

### DIFF
--- a/flutter/flutter/android/build.gradle
+++ b/flutter/flutter/android/build.gradle
@@ -51,10 +51,10 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.5.0'
 
 //start:ffmpeg-kit-https
-//    implementation 'com.arthenica:ffmpeg-kit-https:6.0-2'
+    implementation 'com.arthenica:ffmpeg-kit-https:6.0-2'
 //    FmpegKit has been officially retired.Place dependent libraries locally
 //    The Maven configuration is immutable and currently not required; it’s retained solely as a precaution.
-    implementation files('./libs/ffmpeg-kit-https-6.0-2.aar')
+//    implementation files('./libs/ffmpeg-kit-https-6.0-2.aar')
 
 //start:    smart-exception-java
     implementation files('./libs/smart-exception-java-0.2.1.jar')


### PR DESCRIPTION
## Description
Handle following build issue:
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':ffmpeg_kit_flutter:bundleReleaseLocalLintAar'.
> Error while evaluating property 'hasLocalAarDeps' of task ':ffmpeg_kit_flutter:bundleReleaseLocalLintAar'.
   > Direct local .aar file dependencies are not supported when building an AAR. The resulting AAR would be broken because the classes and Android resources from any local .aar file dependencies would not be packaged in the resulting AAR. Previous versions of the Android Gradle Plugin produce broken AARs in this case too (despite not throwing this error). The following direct local .aar file dependencies of the :ffmpeg_kit_flutter project caused this error: /Users/admin/.pub-cache/git/ffmpeg-kit-ff41066ee575d6eb9749ff943a03d845e51ca39a/flutter/flutter/android/libs/ffmpeg-kit-https-6.0-2.aar

## Type of Change
- Bug fix

## Checks
- [ ] Changes support all platforms (`Android`, `iOS`, `Linux`, `macOS`, `tvOS`)
- [ ] Breaks existing functionality
- [ ] Implementation is completed, not half-done 
- [ ] Is there another PR already created for this feature/bug fix

## Tests
How are these changes verified? Please provide test instructions.
Also list any relevant details about your test configuration.